### PR TITLE
Accumulated fixes - promises, allow overwrite, bpm states, bpm doubler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ or copy projenv.example, modify it, then source it:
 
 Edit web/config.js to point to localhost and update Spotify client id.
 
-Optionally warm up server cache with top 1000 artists (this may take some time):
-
-    $ $(cd server ; python warm.py)
-
 Run server
 
     $ $(cd server ; python server2.py)
+
+Optionally warm up server cache with top 1000 artists (this may take some time):
+
+    $ $(cd server ; python warm.py)
 
 Connect to [http://localhost:8235/SortYourMusic/](http://static.echonest.com/SortYourMusic)

--- a/web/index.html
+++ b/web/index.html
@@ -232,6 +232,8 @@
         src="//cdn.datatables.net/plug-ins/1.10.7/sorting/time.js"></script>
     <script src="lib/bootstrap.min.js"></script>
     <script src="lib/underscore-min.js"></script>
+    <script type="text/javascript" charset="utf-8"
+        src="//cdnjs.cloudflare.com/ajax/libs/q.js/1.4.1/q.min.js"></script>
     <script src="config.js"></script>
 
 <script>
@@ -247,17 +249,20 @@ var cols = [
     'acousticness', 'valence', 'popularity'
 ];
 
-// we keep track of which column we last sorted on so we
-// can enable or disable the save button as appropriate
-var savedOrder = [0, 'asc'];
+// disable save while loading and saving, no matter what the saved state
+var forceDisableSave = false;
+
+// state of the saved playlist, so save button is only shown when different
+var savedState = {};
 
 function error(msg) {
     info(msg);
 }
 
 function getCurSortName() {
-    var prefix = (savedOrder[1] == 'asc') ? 'increasing ' : 'decreasing ';
-    return prefix + cols[savedOrder[0]];
+    var currentState = getPlaylistState();
+    var prefix = (currentState.order[1] == 'asc') ? 'increasing ' : 'decreasing ';
+    return prefix + cols[currentState.order[0]];
 }
 
 function info(msg) {
@@ -312,6 +317,33 @@ function callSpotify(type, url, json, callback) {
     });
 }
 
+function callSpotifyQ(type, url, json) {
+    return Q.Promise(function(resolve, reject, notify) {
+        $.ajax(url, {
+            type: type,
+            data: JSON.stringify(json),
+            dataType: 'json',
+            headers: {
+                'Authorization': 'Bearer ' + accessToken,
+                'Content-Type': 'application/json'
+            },
+            success: function(r) {
+                resolve(r);
+            },
+            error: function(r) {
+                // 2XX status codes are good, but some have no
+                // response data which triggers the error handler
+                // convert it to goodness.
+                if (r.status >= 200 && r.status < 300) {
+                    resolve(r);
+                } else {
+                    reject(r);
+                }
+            }
+        });  
+    });
+}
+
 function getSpotify(url, data, callback) {
     $.ajax(url, {
         dataType: 'json',
@@ -328,6 +360,28 @@ function getSpotify(url, data, callback) {
     });
 }
 
+function getSpotifyQ(type, url, json) {
+    return Q.Promise(function(resolve, reject, notify) {
+        $.ajax(url, {
+            dataType: 'json',
+            data: data,
+            headers: {
+                'Authorization': 'Bearer ' + accessToken
+            },
+            success: function(r) {
+                resolve(r);
+            },
+            error: function(r) {
+                if (r.status >= 200 && r.status < 300) {
+                    resolve(r);
+                } else {
+                    reject(r);
+                }
+            }
+        });
+    });
+}
+
 function showPlaylists() {
     $(".worker").hide();
     $("#playlists").show();
@@ -340,10 +394,9 @@ function fetchSinglePlaylist(playlist) {
     $(".spinner2").show();
     $("#song-table tbody").empty();
     window.scrollTo(0,0);
+    disableSaveButton();
     songTable.clear();
-    songTable.order([0, 'asc']);
-    setNeedsSave(false);
-
+    resetState();
 
     curPlaylist = playlist;
     curPlaylist.tracks.items = [];
@@ -453,6 +506,8 @@ function fetchPlaylistTracks(data) {
     if (tracks.next) {
         getSpotify(tracks.next, null, fetchPlaylistTracks);
     } else {
+        saveState();
+        enableSaveButtonWhenNeeded();
     }
 }
 
@@ -552,6 +607,11 @@ function stopTrack() {
     audio.get(0).pause();
 }
 
+
+// ----------------------------------------------------------------------------
+// Playlist Saving
+// ----------------------------------------------------------------------------
+
 function getSortedUrisFromTable(tracks, table) {
     // Possibly a defect in DataTables: rows() and rows().indexes() returns array in incorrect order
     // Instead, use rows().data() and calculate index from track column.
@@ -559,88 +619,95 @@ function getSortedUrisFromTable(tracks, table) {
         function(rowdata) {return rowdata[11].uri;});
 }
 
-
 function savePlaylist() {
     var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
-    var curOrder = songTable.order();
-    if (curOrder.length > 0) {
-        savedOrder = curOrder[0];
-    }
-    createAndSaveTidsToPlaylist(curPlaylist, tids, function() {
-        setNeedsSave(false);
-    });
+
+    disableSaveButton();
+
+    createAndSaveTidsToPlaylist(curPlaylist, tids)
+    .then(function() {
+        saveState();
+    })
+    .catch(function(msg) {
+        error(msg);
+    })
+    .finally(function() {
+        enableSaveButtonWhenNeeded();
+    })
 }
 
-function saveTidsToPlaylistOld(playlist, tids, first, callback) {
-    var this_tids = tids.slice(0, 100);
-    var remaining = tids.slice(100);
-    var url = "https://api.spotify.com/v1/users/" + playlist.owner.id + 
-         "/playlists/" + playlist.id + '/tracks';
-
-    if (first) {
-        var json = { "uris" : this_tids };
-        callSpotify('PUT', url, json, function(ok, data) {
-            if (ok) {
-                if (remaining.length > 0) {
-                    saveTidsToPlaylist(playlist, remaining, false, callback);
-                } else {
-                    callback(true);
-                }
-            } else {
-                error("Trouble saving to the playlist"); 
-                callback(false);
-            }
-        });
-    } else {
-        var json = this_tids;
-        callSpotify('POST', url, json, function(ok, data) {
-            if (ok) {
-                if (remaining.length > 0) {
-                    saveTidsToPlaylist(playlist, remaining, false, callback);
-                } else {
-                    callback(true);
-                }
-            } else {
-                error("Trouble saving to the playlist"); 
-                callback(false);
-            }
-        });
-    }
-}
-
-function saveTidsToPlaylist(playlist, tids, callback) {
+function saveTidsToPlaylist(playlist, tids) {
     var this_tids = tids.slice(0, 100);
     var remaining = tids.slice(100);
     var json = this_tids;
     var url = "https://api.spotify.com/v1/users/" + playlist.owner.id + 
          "/playlists/" + playlist.id + '/tracks';
 
-    callSpotify('POST', url, json, function(ok, data) {
-        if (ok) {
-            if (remaining.length > 0) {
-                saveTidsToPlaylist(playlist, remaining, callback);
-            } else {
-                callback(true);
-            }
-        } else {
-            error("Trouble saving to the playlist"); 
-            callback(false);
-        }
+    return callSpotifyQ('POST', url, json)
+    .then(function() {
+        if (remaining.length > 0) {
+            return saveTidsToPlaylist(playlist, remaining);
+        } 
+    })
+    .catch(function() {
+        return Q.reject("Trouble saving to the playlist");
     });
 }
 
-function createAndSaveTidsToPlaylist(playlist, tids, callback) {
-    var sortName = getCurSortName();
-    var url = "https://api.spotify.com/v1/users/" + curUserID + "/playlists";
-    var json = { name: curPlaylist.name + " sorted by " + sortName, public: playlist.public };
-    callSpotify('POST', url, json, function(ok, data) {
-        if (ok) {
-            var playlistCopy = data;
-            saveTidsToPlaylist(playlistCopy, tids, callback);
-        } else {
-            error("Can't create the new playlist");
-        }
+function createPlaylist(owner, name, isPublic) {
+    var url = "https://api.spotify.com/v1/users/" + owner.id + "/playlists";
+    var json = { name: name, 'public': isPublic };
+    return callSpotifyQ('POST', url, json)
+    .catch(function() {
+        return Q.reject("Can't create the new playlist");
     });
+}
+
+function createAndSaveTidsToPlaylist(playlist, tids) {
+    var sortName = getCurSortName();
+
+    return createPlaylist(curUserID, curPlaylist.name + " sorted by " + sortName, playlist.public)
+    .then(function(playlistCopy) {
+        return saveTidsToPlaylist(playlistCopy, tids);
+    });
+}
+
+
+// ----------------------------------------------------------------------------
+// Saved playlist state tracking
+// ----------------------------------------------------------------------------
+
+function resetState() {
+    songTable.order([0, 'asc']);
+
+    $('#min-bpm').val(0);
+    $('#max-bpm').val(1000);
+
+    saveState();
+}
+
+// we keep track of which column we last sorted on so we
+// can enable or disable the save button as appropriate
+function getPlaylistState() {
+    var firstOrder = [];
+    var selectedTableOrder = songTable.order();
+    if (selectedTableOrder.length >= 1) {
+        firstOrder = _.clone(selectedTableOrder[0]); // object is reused by datatable!
+    }
+
+    return { 
+        minBpm: parseInt( $('#min-bpm').val(), 10 ),
+        maxBpm: parseInt( $('#max-bpm').val(), 10 ),
+        order: firstOrder,
+    };
+}
+
+function saveState() {
+    savedState = getPlaylistState();
+}
+
+function isSavable() {
+    return !_.isEqual(savedState, getPlaylistState());
 }
 
 function setNeedsSave(state) {
@@ -655,6 +722,21 @@ function setNeedsSave(state) {
     }
 }
 
+function updateSaveButtonState() {
+    setNeedsSave(!forceDisableSave && isSavable());
+}
+
+function disableSaveButton() {
+    forceDisableSave = true;
+    updateSaveButtonState();
+}
+
+function enableSaveButtonWhenNeeded() {
+    forceDisableSave = false;
+    updateSaveButtonState();
+}
+
+
 function initTable() {
     var table = $("#song-table").DataTable( {
             paging: false,
@@ -668,15 +750,7 @@ function initTable() {
      });
 
     table.on('order.dt', function() {
-        var curOrder = table.order();
-        if (curOrder.length >= 1 
-            && curOrder[0][0] == savedOrder[0] 
-            && curOrder[0][1] == savedOrder[1]) {
-            setNeedsSave(false);
-        } else {
-            // different order
-            setNeedsSave(true);
-        }
+        updateSaveButtonState();
     });
 
     $("#song-table tbody").on( 'click', 'tr', function () {
@@ -740,6 +814,7 @@ $(document).ready(
         $.fn.dataTable.ext.search.push(playlistFilter);
         $('#min-bpm, #max-bpm').keyup( function() {
             songTable.draw();
+            updateSaveButtonState();
         });
     }
 );

--- a/web/index.html
+++ b/web/index.html
@@ -327,17 +327,20 @@ function callSpotifyQ(type, url, json) {
                 'Authorization': 'Bearer ' + accessToken,
                 'Content-Type': 'application/json'
             },
-            success: function(r) {
-                resolve(r);
+            beforeSend : function () {
+                console.log(type + ": " + this.url);
             },
-            error: function(r) {
+            success: function(data) {
+                resolve(data);
+            },
+            error: function(jqXHR, textStatus) {
                 // 2XX status codes are good, but some have no
                 // response data which triggers the error handler
                 // convert it to goodness.
-                if (r.status >= 200 && r.status < 300) {
-                    resolve(r);
+                if (jqXHR.status >= 200 && jqXHR.status < 300) {
+                    resolve(undefined);
                 } else {
-                    reject(r);
+                    reject(textStatus);
                 }
             }
         });  
@@ -360,7 +363,7 @@ function getSpotify(url, data, callback) {
     });
 }
 
-function getSpotifyQ(type, url, json) {
+function getSpotifyQ(url, data) {
     return Q.Promise(function(resolve, reject, notify) {
         $.ajax(url, {
             dataType: 'json',
@@ -368,14 +371,17 @@ function getSpotifyQ(type, url, json) {
             headers: {
                 'Authorization': 'Bearer ' + accessToken
             },
-            success: function(r) {
-                resolve(r);
+            beforeSend : function () {
+                console.log("GET: " + this.url);
             },
-            error: function(r) {
-                if (r.status >= 200 && r.status < 300) {
-                    resolve(r);
+            success: function(data) {
+                resolve(data);
+            },
+            error: function(jqXHR, textStatus) {
+                if (jqXHR.status >= 200 && jqXHR.status < 300) {
+                    resolve(undefined);
                 } else {
-                    reject(r);
+                    reject(textStatus);
                 }
             }
         });

--- a/web/index.html
+++ b/web/index.html
@@ -646,8 +646,11 @@ function stopTrack() {
 function getSortedUrisFromTable(tracks, table) {
     // Possibly a defect in DataTables: rows() and rows().indexes() returns array in incorrect order
     // Instead, use rows().data() and calculate index from track column.
-    return _.map(table.rows({filter:'applied'}).data(),
-        function(rowdata) {return rowdata[11].uri;});
+    return _.chain(table.rows({filter:'applied'}).data())
+        // Web API only doesn't support local files for now.
+        .select(function(rowdata) { return rowdata[11].uri.startsWith("spotify:track:"); } )
+        .map (function(rowdata) {return rowdata[11].uri;})
+        .value();
 }
 
 function savePlaylist() {
@@ -695,6 +698,10 @@ function createPlaylist(owner, name, isPublic) {
 }
 
 function createAndSaveTidsToPlaylist(playlist, tids) {
+    if (tids.length <= 0) {
+        return Q.reject("Can't save the new playlist because there are no tracks left after filtering.");
+    }
+
     var sortName = getCurSortName();
 
     return createPlaylist(curUserID, curPlaylist.name + " sorted by " + sortName, playlist.public)

--- a/web/index.html
+++ b/web/index.html
@@ -661,7 +661,7 @@ function saveTidsToPlaylist(playlist, tids) {
 }
 
 function createPlaylist(owner, name, isPublic) {
-    var url = "https://api.spotify.com/v1/users/" + owner.id + "/playlists";
+    var url = "https://api.spotify.com/v1/users/" + curUserID + "/playlists";
     var json = { name: name, 'public': isPublic };
     return callSpotifyQ('POST', url, json)
     .catch(function() {

--- a/web/index.html
+++ b/web/index.html
@@ -164,8 +164,19 @@
 
                     <div class="panel panel-default">
                         <div class="panel-body">
-                            <a class="btn btn-primary btn-sm pull-right" 
-                                id='save' role="button">Save Playlist</a>
+
+                            <div class='btn-group pull-right'>
+                              <button id='save' type='button' class='btn btn-primary btn-sm'>Save New Playlist</button>
+                              <button type='button' class='btn btn-primary btn-sm dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
+                                <span class='caret'></span>
+                                <span class='sr-only'>Toggle Dropdown</span>
+                              </button>
+                              <ul class='dropdown-menu'>
+                                <li><a id='dropSave' href='#'>Save New Playlist</a></li>
+                                <li><a id='dropOverwrite' href='#'>Overwrite Playlist</a></li>
+                              </ul>
+                            </div>
+
                             <a class="btn btn-primary btn-sm pull-left" id='pick'
                                 role="button">back</a>
                         </div>
@@ -653,6 +664,7 @@ function getSortedUrisFromTable(tracks, table) {
         .value();
 }
 
+// (#save,#dropSave).onclick
 function savePlaylist() {
     var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
 
@@ -670,17 +682,44 @@ function savePlaylist() {
     })
 }
 
-function saveTidsToPlaylist(playlist, tids) {
+// #dropOverwrite.onclick
+function overwritePlaylist() {
+    var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
+
+    disableSaveButton();
+
+    replaceTidsInPlaylist(curPlaylist, tids)
+    .then(function() {
+        saveState();
+    })
+    .catch(function(msg) {
+        error(msg);
+    })
+    .finally(function() {
+        enableSaveButtonWhenNeeded();
+    })
+}
+
+function saveTidsToPlaylist(playlist, tids, replace) {
     var this_tids = tids.slice(0, 100);
     var remaining = tids.slice(100);
-    var json = this_tids;
     var url = "https://api.spotify.com/v1/users/" + playlist.owner.id + 
          "/playlists/" + playlist.id + '/tracks';
+    var type;
+    var json;
 
-    return callSpotifyQ('POST', url, json)
+    if (replace) {
+        type = 'PUT';
+        json = { 'uris': this_tids };
+    } else {
+        type = 'POST';
+        json = this_tids;
+    }
+
+    return callSpotifyQ(type, url, json)
     .then(function() {
         if (remaining.length > 0) {
-            return saveTidsToPlaylist(playlist, remaining);
+            return saveTidsToPlaylist(playlist, remaining, false);
         } 
     })
     .catch(function() {
@@ -706,8 +745,16 @@ function createAndSaveTidsToPlaylist(playlist, tids) {
 
     return createPlaylist(curUserID, curPlaylist.name + " sorted by " + sortName, playlist.public)
     .then(function(playlistCopy) {
-        return saveTidsToPlaylist(playlistCopy, tids);
+        return saveTidsToPlaylist(playlistCopy, tids, false);
     });
+}
+
+function replaceTidsInPlaylist(playlist, tids) {
+    if (tids.length <= 0) {
+        return Q.reject("Can't replace tracks in playlist because there are no tracks left after filtering.");
+    }
+
+    return saveTidsToPlaylist(playlist, tids, true);
 }
 
 
@@ -841,8 +888,11 @@ $(document).ready(
 
         }
 
-        $("#save").on('click', function() {
+        $("#save,#dropSave").on('click', function() {
             savePlaylist();
+        });
+        $("#dropOverwrite").on('click', function() {
+            overwritePlaylist();
         });
 
         $("#pick").on('click', function() {

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,7 @@
     <link href="dist/sp-bootstrap.min.css" rel="stylesheet" media="screen">
     <link rel="stylesheet" type="text/css"
     href="//cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="shortcut icon" href="images/favicon.png">
     <title>Sort Your Music</title>
     <!-- Custom styles for this template -->
@@ -166,7 +167,7 @@
                         <div class="panel-body">
 
                             <div class='btn-group pull-right'>
-                              <button id='save' type='button' class='btn btn-primary btn-sm'>Save New Playlist</button>
+                              <button id='save' type='button' class='btn btn-primary btn-sm has-spinner'><i class="fa fa-spinner fa-spin"></i> Save New Playlist</button>
                               <button id='saveDropdown' type='button' class='btn btn-primary btn-sm dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
                                 <span class='caret'></span>
                                 <span class='sr-only'>Toggle Dropdown</span>
@@ -669,6 +670,7 @@ function savePlaylist() {
     var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
 
     disableSaveButton();
+    showSaveSpinner(true);
 
     createAndSaveTidsToPlaylist(curPlaylist, tids)
     .then(function() {
@@ -678,6 +680,7 @@ function savePlaylist() {
         error(msg);
     })
     .finally(function() {
+        showSaveSpinner(false);
         enableSaveButtonWhenNeeded();
     })
 }
@@ -687,6 +690,7 @@ function overwritePlaylist() {
     var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
 
     disableSaveButton();
+    showSaveSpinner(true);
 
     replaceTidsInPlaylist(curPlaylist, tids)
     .then(function() {
@@ -696,13 +700,15 @@ function overwritePlaylist() {
         error(msg);
     })
     .finally(function() {
+        showSaveSpinner(false);
         enableSaveButtonWhenNeeded();
     })
 }
 
 function saveTidsToPlaylist(playlist, tids, replace) {
-    var this_tids = tids.slice(0, 100);
-    var remaining = tids.slice(100);
+    var sliceLength = 100;
+    var this_tids = tids.slice(0, sliceLength);
+    var remaining = tids.slice(sliceLength);
     var url = "https://api.spotify.com/v1/users/" + playlist.owner.id + 
          "/playlists/" + playlist.id + '/tracks';
     var type;
@@ -821,6 +827,13 @@ function enableSaveButtonWhenNeeded() {
     updateSaveButtonState();
 }
 
+function showSaveSpinner(showSpinner) {
+    if (showSpinner) {
+        $('#save').addClass('active');
+    } else {
+        $('#save').removeClass('active');
+    }
+}
 
 function initTable() {
     var table = $("#song-table").DataTable( {

--- a/web/index.html
+++ b/web/index.html
@@ -665,34 +665,22 @@ function getSortedUrisFromTable(tracks, table) {
         .value();
 }
 
-// (#save,#dropSave).onclick
-function savePlaylist() {
-    var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
+// (#save,#dropSave,#dropOverwrite).onclick
+function savePlaylist(playlist, createNewPlaylist) {
+    var tids = getSortedUrisFromTable(playlist.tracks.items, songTable);
+
+    if (tids.length <= 0) {
+        error("Cannot save the playlist because there are no tracks left after filtering");
+        return;
+    }
 
     disableSaveButton();
     showSaveSpinner(true);
 
-    createAndSaveTidsToPlaylist(curPlaylist, tids)
-    .then(function() {
-        saveState();
+    createOrReusePlaylist(playlist, createNewPlaylist)
+    .then(function(playlistToModify) {
+        return saveTidsToPlaylist(playlistToModify, tids, true);
     })
-    .catch(function(msg) {
-        error(msg);
-    })
-    .finally(function() {
-        showSaveSpinner(false);
-        enableSaveButtonWhenNeeded();
-    })
-}
-
-// #dropOverwrite.onclick
-function overwritePlaylist() {
-    var tids = getSortedUrisFromTable(curPlaylist.tracks.items, songTable);
-
-    disableSaveButton();
-    showSaveSpinner(true);
-
-    replaceTidsInPlaylist(curPlaylist, tids)
     .then(function() {
         saveState();
     })
@@ -729,38 +717,26 @@ function saveTidsToPlaylist(playlist, tids, replace) {
         } 
     })
     .catch(function() {
-        return Q.reject("Trouble saving to the playlist");
+        return Q.reject("Trouble saving tracks to the playlist");
     });
 }
 
 function createPlaylist(owner, name, isPublic) {
-    var url = "https://api.spotify.com/v1/users/" + curUserID + "/playlists";
+    var url = "https://api.spotify.com/v1/users/" + owner + "/playlists";
     var json = { name: name, 'public': isPublic };
     return callSpotifyQ('POST', url, json)
     .catch(function() {
-        return Q.reject("Can't create the new playlist");
+        return Q.reject("Cannot create the new playlist");
     });
 }
 
-function createAndSaveTidsToPlaylist(playlist, tids) {
-    if (tids.length <= 0) {
-        return Q.reject("Can't save the new playlist because there are no tracks left after filtering.");
+function createOrReusePlaylist(playlist, createNewPlaylist) {
+    if (createNewPlaylist) {
+        var sortName = getCurSortName();
+        return createPlaylist(curUserID, playlist.name + " sorted by " + sortName, playlist.public);
+    } else {
+        return Q(playlist);
     }
-
-    var sortName = getCurSortName();
-
-    return createPlaylist(curUserID, curPlaylist.name + " sorted by " + sortName, playlist.public)
-    .then(function(playlistCopy) {
-        return saveTidsToPlaylist(playlistCopy, tids, false);
-    });
-}
-
-function replaceTidsInPlaylist(playlist, tids) {
-    if (tids.length <= 0) {
-        return Q.reject("Can't replace tracks in playlist because there are no tracks left after filtering.");
-    }
-
-    return saveTidsToPlaylist(playlist, tids, true);
 }
 
 
@@ -898,14 +874,13 @@ $(document).ready(
             $("#go").on('click', function() {
                 authorizeUser();
             });
-
         }
 
         $("#save,#dropSave").on('click', function() {
-            savePlaylist();
+            savePlaylist(curPlaylist, true);
         });
         $("#dropOverwrite").on('click', function() {
-            overwritePlaylist();
+            savePlaylist(curPlaylist, false);
         });
 
         $("#pick").on('click', function() {

--- a/web/index.html
+++ b/web/index.html
@@ -256,6 +256,7 @@ var forceDisableSave = false;
 var savedState = {};
 
 function error(msg) {
+    console.error(msg);
     info(msg);
 }
 
@@ -410,14 +411,16 @@ function fetchSinglePlaylist(playlist) {
     $("#playlist-title").text(playlist.name);
     $("#playlist-title").attr('href', playlist.uri);
 
-     var url = "https://api.spotify.com/v1/users/" + playlist.owner.id 
-        + "/playlists/" + playlist.id
+    info("");
 
-    var data = {
-        limit:100,
-        offset:0
-    }
-    getSpotify(url, data, fetchPlaylistTracks);
+    fetchPlaylistTracks(playlist)
+    .then(function() {
+        saveState();
+        enableSaveButtonWhenNeeded();
+    })
+    .catch(function(msg) {
+        error("Error while loading playlist: " + msg);
+    });
 }
 
 function findDuplicates(playlist) {
@@ -443,15 +446,23 @@ function formatDuration(dur) {
     return mins + ":" + ssecs;
 }
 
-function fetchENTrackInfo(ids, callback) {
+function fetchENTrackInfo(ids) {
     var cids = ids.join(',');
     var url = API_HOST + '/songs';
-    $.getJSON(url, { ids : cids}, callback);
+    return Q.Promise(function(resolve, reject, notify) {
+        $.ajax({
+            url: url,
+            dataType: 'json',
+            data: {ids : cids},
+            beforeSend : function () { console.log("GET: " + this.url); },
+            success: function(data) { resolve(data); },
+            error: function(jqXHR, textStatus) { reject(textStatus); }
+        });
+    });
 }
 
 function updateTable(tracks) {
     $("#single-playlist-contents").show();
-    info("");
     _.each(tracks.items, function(item, i) {
         var track = item.track;
         addTrack(songTable, track);
@@ -494,27 +505,41 @@ function addTrack(table,track) {
     }
 }
 
-function fetchPlaylistTracks(data) {
-    var ids = [];
+function fetchPlaylistTracks(playlist) {
 
-    var tracks = data.tracks ? data.tracks : data;
-    _.each(tracks.items, function(item, i) {
-        item.track.which = curPlaylist.tracks.items.length;
-        curPlaylist.tracks.items.push(item);
-        ids.push(item.track.id);
-    });
-    fetchENTrackInfo(ids, function(enInfo) {
-        _.each(enInfo.songs, function(song, i) {
-            tracks.items[i].track.enInfo = song;
-        });
-        updateTable(tracks);
-    });
-    if (tracks.next) {
-        getSpotify(tracks.next, null, fetchPlaylistTracks);
-    } else {
-        saveState();
-        enableSaveButtonWhenNeeded();
+    function fetchLoop(url) {
+        var tracks;
+
+        return getSpotifyQ(url)
+        .then(function(data) {
+            var ids = [];
+
+            tracks = data.tracks ? data.tracks : data;
+
+            _.each(tracks.items, function(item, i) {
+                item.track.which = curPlaylist.tracks.items.length;
+                curPlaylist.tracks.items.push(item);
+                ids.push(item.track.id);
+            });
+
+            return fetchENTrackInfo(ids)
+        })
+        .then(function(enInfo) {
+            _.each(enInfo.songs, function(song, i) {
+                tracks.items[i].track.enInfo = song;
+            });
+            updateTable(tracks);
+
+            if (tracks.next) {
+                return fetchLoop(tracks.next);
+            }
+        })
+        
     }
+
+    // Spotify API defect? specifying limit will actually return up to 100 items anyway.
+    var startUrl = "https://api.spotify.com/v1/users/" + playlist.owner.id + "/playlists/" + playlist.id;
+    return fetchLoop(startUrl);
 }
 
 function fetchPlaylists(uid, callback) {

--- a/web/index.html
+++ b/web/index.html
@@ -680,8 +680,8 @@ function createAndSaveTidsToPlaylist(playlist, tids) {
 function resetState() {
     songTable.order([0, 'asc']);
 
-    $('#min-bpm').val(0);
-    $('#max-bpm').val(1000);
+    $('#min-bpm').val("");
+    $('#max-bpm').val("");
 
     saveState();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -195,6 +195,10 @@
                                     <label for="max-bpm">Maximum BPM</label>
                                     <input id="max-bpm" type="number" class="form-control" placeholder="1000">
                                 </div>
+                                <div class="form-group">
+                                    <label for="include-double">Include Doubled BPM</label>
+                                    <input id="include-double" type="checkbox" checked="checked">
+                                </div>
                                 <!-- <button id="filter-button" class="btn btn-default btn-sm">Filter</button> -->
                             </div>
                         </div>
@@ -630,15 +634,21 @@ function loadPlaylists(uid) {
     fetchPlaylists(uid, playlistLoaded);
 }
 
+function inRange(val, min, max) {
+    return ( ( isNaN(min) && isNaN(max) ) ||
+             ( isNaN(min) && val <= max ) ||
+             ( min <= val && isNaN(max) ) ||
+             ( min <= val && val <= max ) );
+}
+
 function playlistFilter( settings, data, dataIndex ) {
     var minBpm = parseInt( $('#min-bpm').val(), 10 );
     var maxBpm = parseInt( $('#max-bpm').val(), 10 );
+    var includeDouble = $('#include-double').is(':checked');
     var bpm = parseFloat( data[3] ) || 0;
 
-    return ( ( isNaN( minBpm ) && isNaN( maxBpm ) ) ||
-         ( isNaN( minBpm ) && bpm <= maxBpm ) ||
-         ( minBpm <= bpm   && isNaN( maxBpm ) ) ||
-         ( minBpm <= bpm   && bpm <= maxBpm ) );
+    return inRange(bpm, minBpm, maxBpm) || 
+        (includeDouble && inRange(bpm*2, minBpm, maxBpm));
 }
 
 function playTrack(track) {
@@ -749,6 +759,7 @@ function resetState() {
 
     $('#min-bpm').val("");
     $('#max-bpm').val("");
+    $('#include-double').prop('checked', true);
 
     saveState();
 }
@@ -765,6 +776,7 @@ function getPlaylistState() {
     return { 
         minBpm: parseInt( $('#min-bpm').val(), 10 ),
         maxBpm: parseInt( $('#max-bpm').val(), 10 ),
+        includeDouble: $('#include-double').is(':checked'),
         order: firstOrder,
     };
 }
@@ -888,7 +900,7 @@ $(document).ready(
         });
 
         $.fn.dataTable.ext.search.push(playlistFilter);
-        $('#min-bpm, #max-bpm').keyup( function() {
+        $('#min-bpm,#max-bpm,#include-double').on('keyup change', function() {
             songTable.draw();
             updateSaveButtonState();
         });

--- a/web/index.html
+++ b/web/index.html
@@ -167,7 +167,7 @@
 
                             <div class='btn-group pull-right'>
                               <button id='save' type='button' class='btn btn-primary btn-sm'>Save New Playlist</button>
-                              <button type='button' class='btn btn-primary btn-sm dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
+                              <button id='saveDropdown' type='button' class='btn btn-primary btn-sm dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
                                 <span class='caret'></span>
                                 <span class='sr-only'>Toggle Dropdown</span>
                               </button>
@@ -797,13 +797,13 @@ function isSavable() {
 
 function setNeedsSave(state) {
     if (state) {
-        $("#save").attr('disabled', false);
-        $("#save").removeClass('btn-warning');
-        $("#save").addClass('btn-primary');
+        $("#save,#saveDropdown").attr('disabled', false);
+        $("#save,#saveDropdown").removeClass('btn-warning');
+        $("#save,#saveDropdown").addClass('btn-primary');
     } else {
-        $("#save").attr('disabled', true);
-        $("#save").addClass('btn-warning');
-        $("#save").removeClass('btn-primary');
+        $("#save,#saveDropdown").attr('disabled', true);
+        $("#save,#saveDropdown").addClass('btn-warning');
+        $("#save,#saveDropdown").removeClass('btn-primary');
     }
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -122,3 +122,27 @@ view) */
 #playlist-list th {
   font-weight: bold
 }
+
+
+/* Loading spinner based on following stackoverflow answer:
+    http://stackoverflow.com/questions/15982233/spinner-for-twitter-bootstrap-btn 
+    http://jsfiddle.net/oshybystyi/v04ag5ch/4/ */
+    
+.has-spinner .fa-spinner {
+  opacity: 0;
+  max-width: 0;
+
+  -webkit-transition: opacity 0.25s, max-width 0.45s; 
+  -moz-transition: opacity 0.25s, max-width 0.45s;
+  -o-transition: opacity 0.25s, max-width 0.45s;
+  transition: opacity 0.25s, max-width 0.45s; /* Duration fixed since we animate additional hidden width */
+}
+
+.has-spinner.active {
+  cursor:progress;
+}
+
+.has-spinner.active .fa-spinner {
+  opacity: 1;
+  max-width: 50px; /* More than it will ever come, notice that this affects on animation duration */
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -123,11 +123,14 @@ view) */
   font-weight: bold
 }
 
+#min-bpm,#max-bpm {
+  width:100px;
+}
 
 /* Loading spinner based on following stackoverflow answer:
     http://stackoverflow.com/questions/15982233/spinner-for-twitter-bootstrap-btn 
     http://jsfiddle.net/oshybystyi/v04ag5ch/4/ */
-    
+
 .has-spinner .fa-spinner {
   opacity: 0;
   max-width: 0;

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -41,25 +41,25 @@ Playlists View:
 Tracks View:
 - defect: if press 'back' in middle of loading playlist: when viewing new playlist, continues to load in old one
 - defect: shows 100-147 in some compilations (instead of 1 - 147) <-- possibly fixed by new track loader
-- spinning icon while saving.
 - BPM doubler for filter (80bpm can count for 160)
 - filter BPM with base tempo +- chosen range (eg, I want 160bpm within 3%)
 - show loading progress, ie how much is remaining.
-- save/add to/replace playlist (like button in spotify)
 - map bpm to custom graph over time (eg, a playlist that slowly ramps up then down again quickly)
 - DONE: defect: changing bpm filter doesn't affect save button.
 - DONE: defect?: is order of loaded playlist retained when loading slowly from server?
 - DONE: disable sorting until fully loaded.
 - DONE: defect: can't save if local files in list.
+- DONE: save/add to/replace playlist (like button in spotify)
+- DONE: spinning icon while saving.
 
 Client Architectural:
+- WIP: use promises instead of callbacks (what about progress reporting)
 - move js out of index.html into app.js
 - upgrade other libraries. 
 - use CDN for everything or migrate CDN libraries to local.
 - local storage for caching of track and owner info.
 - show loaded tracks immediately (without song info), then fill in details as loaded.
-- WIP: use promises instead of callbacks (what about progress reporting)
-- migrate to ember or angular or react?
+- Investigate migrating to AngularJS
 - use templating?
 - DONE: only make one request at a time to cut down load on api server.
 

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -35,13 +35,12 @@ Playlists View:
 - filter owned/followed lists
 - loading progress (how much is remaining?)
 - sorting by name, last modified, owner, etc
-- select multiple playlists to filter
+- select multiple playlists to filter (disable overwrite if multiple)
 - folder view (requires api)
 
 Tracks View:
 - defect: if press 'back' in middle of loading playlist: when viewing new playlist, continues to load in old one
 - defect: shows 100-147 in some compilations (instead of 1 - 147) <-- possibly fixed by new track loader
-- BPM doubler for filter (80bpm can count for 160)
 - filter BPM with base tempo +- chosen range (eg, I want 160bpm within 3%)
 - show loading progress, ie how much is remaining.
 - map bpm to custom graph over time (eg, a playlist that slowly ramps up then down again quickly)
@@ -51,6 +50,7 @@ Tracks View:
 - DONE: defect: can't save if local files in list.
 - DONE: save/add to/replace playlist (like button in spotify)
 - DONE: spinning icon while saving.
+- DONE: BPM doubler for filter (80bpm can count for 160)
 
 Client Architectural:
 - WIP: use promises instead of callbacks (what about progress reporting)

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -40,8 +40,8 @@ Playlists View:
 
 Tracks View:
 - defect: if press 'back' in middle of loading playlist: when viewing new playlist, continues to load in old one
-- defect: shows 100-147 in some compilations (instead of 1 - 147)
-- defect: can't save if local files in list.
+- defect: shows 100-147 in some compilations (instead of 1 - 147) <-- possibly fixed by new track loader
+- spinning icon while saving.
 - BPM doubler for filter (80bpm can count for 160)
 - filter BPM with base tempo +- chosen range (eg, I want 160bpm within 3%)
 - show loading progress, ie how much is remaining.
@@ -50,6 +50,7 @@ Tracks View:
 - DONE: defect: changing bpm filter doesn't affect save button.
 - DONE: defect?: is order of loaded playlist retained when loading slowly from server?
 - DONE: disable sorting until fully loaded.
+- DONE: defect: can't save if local files in list.
 
 Client Architectural:
 - move js out of index.html into app.js
@@ -64,6 +65,7 @@ Client Architectural:
 
 Server Architectural:
 - defect?: does warm.py affect the cache?
+- defect: db lazy init (get_db) is possibly not thread safe if two requests come in at same time
 - DONE: is sharing the cache object thread safe?
 - WONTFIX: sqlite/other db support using sqlalchemy (better concurrency)
 - DONE: use leveldb

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -64,13 +64,15 @@ Client Architectural:
 - DONE: only make one request at a time to cut down load on api server.
 
 Server Architectural:
-- defect?: does warm.py affect the cache?
 - defect: db lazy init (get_db) is possibly not thread safe if two requests come in at same time
+- optional redis backend for multi-process?
+- warm.py: specify url on command line.
 - DONE: is sharing the cache object thread safe?
 - WONTFIX: sqlite/other db support using sqlalchemy (better concurrency)
 - DONE: use leveldb
 - DONE: save cache periodically 
 - DONE: use flask intead of cherrpy? (bigger community, how does it affect )
+- NOTDEFCT: defect?: does warm.py affect the cache?
 
 Deployment:
 - Documentation for submitting code

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -42,18 +42,17 @@ Tracks View:
 - defect: if press 'back' in middle of loading playlist: when viewing new playlist, continues to load in old one
 - defect: shows 100-147 in some compilations (instead of 1 - 147)
 - defect: can't save if local files in list.
-- defect?: is order of loaded playlist retained when loading slowly from server?
 - BPM doubler for filter (80bpm can count for 160)
 - filter BPM with base tempo +- chosen range (eg, I want 160bpm within 3%)
 - show loading progress, ie how much is remaining.
 - save/add to/replace playlist (like button in spotify)
 - map bpm to custom graph over time (eg, a playlist that slowly ramps up then down again quickly)
 - DONE: defect: changing bpm filter doesn't affect save button.
+- DONE: defect?: is order of loaded playlist retained when loading slowly from server?
 - DONE: disable sorting until fully loaded.
 
 Client Architectural:
 - move js out of index.html into app.js
-- only make one request at a time to cut down load on api server.
 - upgrade other libraries. 
 - use CDN for everything or migrate CDN libraries to local.
 - local storage for caching of track and owner info.
@@ -61,6 +60,7 @@ Client Architectural:
 - WIP: use promises instead of callbacks (what about progress reporting)
 - migrate to ember or angular or react?
 - use templating?
+- DONE: only make one request at a time to cut down load on api server.
 
 Server Architectural:
 - defect?: does warm.py affect the cache?

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -43,6 +43,7 @@ Tracks View:
 - defect: filtering doesn't affect saving.
 - defect: can't save if local files in list.
 - defect?: is order of loaded playlist retained when loading slowly from server?
+- DONE: defect: changing bpm filter doesn't affect save button.
 - BPM doubler for filter (80bpm can count for 160)
 - disable sorting until fully loaded.
 - filter BPM with base tempo +- chosen range (eg, I want 160bpm within 3%)
@@ -57,7 +58,7 @@ Client Architectural:
 - use CDN for everything or migrate CDN libraries to local.
 - local storage for caching of track and owner info.
 - show loaded tracks immediately (without song info), then fill in details as loaded.
-- use promises instead of callbacks (what about progress reporting)
+- WIP: use promises instead of callbacks (what about progress reporting)
 - migrate to ember or angular or react?
 - use templating?
 

--- a/web/todo.txt
+++ b/web/todo.txt
@@ -39,17 +39,17 @@ Playlists View:
 - folder view (requires api)
 
 Tracks View:
+- defect: if press 'back' in middle of loading playlist: when viewing new playlist, continues to load in old one
 - defect: shows 100-147 in some compilations (instead of 1 - 147)
-- defect: filtering doesn't affect saving.
 - defect: can't save if local files in list.
 - defect?: is order of loaded playlist retained when loading slowly from server?
-- DONE: defect: changing bpm filter doesn't affect save button.
 - BPM doubler for filter (80bpm can count for 160)
-- disable sorting until fully loaded.
 - filter BPM with base tempo +- chosen range (eg, I want 160bpm within 3%)
 - show loading progress, ie how much is remaining.
 - save/add to/replace playlist (like button in spotify)
 - map bpm to custom graph over time (eg, a playlist that slowly ramps up then down again quickly)
+- DONE: defect: changing bpm filter doesn't affect save button.
+- DONE: disable sorting until fully loaded.
 
 Client Architectural:
 - move js out of index.html into app.js


### PR DESCRIPTION
Some of the features kind of built up. Let me know if you'd like me to break it up.

- refactor some queries to use promises, simplifying code
- allow overwriting playlists instead of saving new - new dropdown option
- include doubled bpm in filter
- load playlist tracks one request at a time from API server, cutting down load
- fix defect where changing bpm filter wouldn't enable resaving playlist
- don't attempt to save local files to new playlist
- spinner on button during save.