### PR TITLE
Fix "Cannot read property 'id' of null" error when features not found

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -499,7 +499,7 @@ function addTrack(table,track) {
                 '',
                 '',
                 '',
-                '',
+                // '',
                 '',
                 '',
                 track
@@ -529,7 +529,9 @@ function fetchPlaylistTracks(playlist) {
         .then(function(trackFeatures) {
             var fmap = {};
             _.each(trackFeatures, function(trackFeature, i) {
-                fmap[trackFeature.id] = trackFeature;
+                if (trackFeature) {
+                    fmap[trackFeature.id] = trackFeature;
+                }
             });
 
             _.each(tracks.items, function(item, i) {


### PR DESCRIPTION
Fixes an error when the audio-features call wasn't getting a result, meaning couldn't save the playlist.

Here's a track that returned empty feature data: https://open.spotify.com/track/1cWYkTVkWdTQgimpFBdUlV