### PR TITLE
Fix Spotify Web API request "PUT /playlists/{playlist_id}/tracks"

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -866,8 +866,7 @@ function saveTidsToPlaylist(playlist, tids, replace) {
     var sliceLength = 100;
     var this_tids = tids.slice(0, sliceLength);
     var remaining = tids.slice(sliceLength);
-    var url = "https://api.spotify.com/v1/users/" + playlist.owner.id + 
-         "/playlists/" + playlist.id + '/tracks';
+    var url = "https://api.spotify.com/v1/playlists/" + playlist.id + '/tracks';
     var type;
     var json;
 


### PR DESCRIPTION
The "Create New Playlist" button does not work anymore, which is probably due to Spotify having changed its Web API at some point.
The `playlists` resource is now (only) accessible directly at the root of the API. 

See documentation: https://developer.spotify.com/documentation/web-api/reference/reorder-or-replace-playlists-tracks

@plamere @sonneveld 