### PR TITLE
Update redirect URI to use HTTPS for improved security

### DIFF
--- a/web/config.js
+++ b/web/config.js
@@ -2,5 +2,5 @@
 
 var SPOTIFY_CLIENT_ID = '31469b011d4941bf8dd4ac9cf8495bac';
 var SPOTIFY_REDIRECT_URI = 'http://localhost:8000/';
-var SPOTIFY_REDIRECT_URI = 'http://sortyourmusic.playlistmachinery.com/';
+var SPOTIFY_REDIRECT_URI = 'https://sortyourmusic.playlistmachinery.com/';
 


### PR DESCRIPTION
<img width="1642" height="724" alt="image" src="https://github.com/user-attachments/assets/f703e1b7-6104-428a-947d-d0bb17be5d4d" />
Although this fixes the issue currently in prod, there is no HTTPS version for your domain, maybe try to add SSL to domain first before merging this PR as it is required by Spotify API.