### PR TITLE
issue #71 - fixed (show_Dialog)

### DIFF
--- a/web2/js/auth.js
+++ b/web2/js/auth.js
@@ -21,7 +21,7 @@ function base64urlEncode(buffer) {
     .replace(/\//g, '_');
 }
 
-export async function redirectToSpotifyAuth() {
+export async function redirectToSpotifyAuth(showDialog = false) {
   const codeVerifier = generateRandomString(64);
   localStorage.setItem('code_verifier', codeVerifier);
 
@@ -35,6 +35,7 @@ export async function redirectToSpotifyAuth() {
     redirect_uri: SPOTIFY_REDIRECT_URI,
     code_challenge_method: 'S256',
     code_challenge: codeChallenge,
+    show_dialog: String(showDialog),
   });
 
   window.location.href = `https://accounts.spotify.com/authorize?${params}`;
@@ -114,4 +115,5 @@ export function hasValidToken() {
 export function clearTokens() {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem('code_verifier');
+  localStorage.setItem('force_show_dialog', 'true');
 }

--- a/web2/js/views/landing.js
+++ b/web2/js/views/landing.js
@@ -13,7 +13,11 @@ export function renderLanding(container) {
       el('p', { class: 'hero-prompt' }, 'Login with your Spotify account to get started'),
       el('button', {
         class: 'btn btn--primary btn--lg',
-        on: { click: () => redirectToSpotifyAuth() },
+          on: { click: () => {
+            const forceDialog = localStorage.getItem('force_show_dialog') === 'true';
+            localStorage.removeItem('force_show_dialog');
+            redirectToSpotifyAuth(forceDialog);
+        }},
       }, 'Login with Spotify'),
       el('div', { class: 'hero-trust' },
         el('p', {}, 'Sorting playlists since 2012 · Millions of playlists sorted'),


### PR DESCRIPTION
**Bug Description**
After logging in with a Google account and then logging out, the login dialog is skipped on the next login attempt. The user is automatically re-authenticated with the previously used Google account, making it impossible to switch to email/password login.

**Steps to Reproduce**

1. Open the app and click "Login with Spotify"
2. On the Spotify login page, choose "Continue with Google"
3. Complete the login
4. Click "Logout"
5. Click "Login with Spotify" again

**Expected Behavior**
The Spotify login dialog appears, allowing the user to choose between Google and email/password login.

**Actual Behavior**
The Spotify login dialog is skipped entirely. The user is silently re-authenticated via their still-active Google session.

**Root Cause**
The Spotify OAuth authorization URL was built without the show_dialog parameter. When omitted, Spotify skips the login dialog if an active session exists. After logout, only the local tokens were cleared — the Spotify/Google session remained active on accounts.spotify.com.
Changes

auth.js — added showDialog parameter to redirectToSpotifyAuth() and show_dialog to the OAuth URL
auth.js — clearTokens() now sets a force_show_dialog flag in localStorage
views/landing.js — login button reads the flag and passes it to redirectToSpotifyAuth()